### PR TITLE
 Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -51,7 +51,7 @@ indent "Saving environment setup script..."
 mkdir -p $PROFILE_D_DIR
 cat << EOF > $PROFILE_D_DIR/oracle.sh
 #!/usr/bin/env bash
-export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:$HOME/.apt/lib/x86_64-linux-gnu:$HOME/vendor/oracle/instantclient_12_1"
+export LD_LIBRARY_PATH="\$LD_LIBRARY_PATH:\$HOME/.apt/lib/x86_64-linux-gnu:\$HOME/vendor/oracle/instantclient_12_1"
 EOF
 
 indent "Done."


### PR DESCRIPTION
Hi! I'm on the team that maintains Heroku's build system.

In the next week or so we plan on changing the value for `$HOME` at build time as part of moving where the build occurs, however this buildpack was found to not be compatible with this change, which will be fixed by this PR.

---

Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`, which would cause this buildpack to break.

By escaping the dollar sign, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.